### PR TITLE
Fix for #5: Clean HTML from description. Make capacity fields contain integers. If description or type is null, make it an empty string.

### DIFF
--- a/bicycle_parking.geojson
+++ b/bicycle_parking.geojson
@@ -2053,7 +2053,7 @@
       "type": "Feature",
       "properties": {
         "name": "UC Plaza",
-        "description": "8 spaces: 3�Wave Racks",
+        "description": "8 spaces: 3 Wave Racks",
         "type": "3 Wave Racks",
         "capacity": 8
       },


### PR DESCRIPTION
Please review!
